### PR TITLE
composer: min PHP 5.4 added

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
 	"issues": "http://github.com/mothership-ec/up/issues"
   },
   "require": {
+  	"php": ">=5.4",
 	"mothership-ec/composer": "~1.0"
   },
   "require-dev": {


### PR DESCRIPTION
Looks like it's the minimum (found short array syntax).
